### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 This server, based on the [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol), allows **Claude** or any other MCP-compatible client to interact with your [Audiense Insights](https://www.audiense.com/) account. It extracts **marketing insights and audience analysis** from Audiense reports, covering **demographic, cultural, influencer, and content engagement analysis**.
 
+<a href="https://glama.ai/mcp/servers/xz11vmv38c"><img width="380" height="200" src="https://glama.ai/mcp/servers/xz11vmv38c/badge" alt="Audiense Insights Server MCP server" /></a>
+
 ---
 
 ## 🚀 Prerequisites


### PR DESCRIPTION
This PR adds a badge for the [Audiense Insights MCP Server](https://glama.ai/mcp/servers/xz11vmv38c) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/xz11vmv38c"><img width="380" height="200" src="https://glama.ai/mcp/servers/xz11vmv38c/badge" alt="Audiense Insights Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.