### PR TITLE
feat: npx support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-audiense-insights",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-audiense-insights",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "APACHE 2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,13 @@
   },
   "scripts": {
     "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
+    "prepare": "npm run build",
     "test": "jest"
   },
   "files": [
-    "build"
+    "build",
+    "src",
+    "tsconfig.json"
   ],
   "keywords": [],
   "author": "",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";


### PR DESCRIPTION
Adds support for npx by adding a required prepare script to build the package at runtime and adding the node shebang.

PD: A regular npm install caused a package-lock edit because the package versions in the lock file weren't matching the version in the package.json