### PR TITLE
feat - tests + evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,3 +228,12 @@ Get-Content -Path "$env:AppData\Claude\Logs\mcp*.log" -Wait -Tail 20
 ## 📄 License
 
 This project is licensed under the Apache 2.0 License. See the LICENSE file for more details.
+
+
+## Running evals
+
+The evals package loads an mcp client that then runs the index.ts file, so there is no need to rebuild between tests. You can load environment variables by prefixing the npx command. Full documentation can be found [here](https://www.mcpevals.io/docs).
+
+```bash
+OPENAI_API_KEY=your-key  npx mcp-eval src/evals/evals.ts src/index.ts
+```

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "base-64": "^1.0.0",
     "dotenv": "^16.4.7",
     "node-fetch": "^3.3.2",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "mcp-evals": "^1.0.18"
   },
   "devDependencies": {
     "@types/base-64": "^1.0.2",

--- a/src/evals/evals.ts
+++ b/src/evals/evals.ts
@@ -1,0 +1,59 @@
+//evals.ts
+
+import { EvalConfig } from 'mcp-evals';
+import { openai } from "@ai-sdk/openai";
+import { grade, EvalFunction } from "mcp-evals";
+
+const getReportsEval: EvalFunction = {
+    name: "get-reports",
+    description: "Evaluates the retrieval of Audiense insights reports for the authenticated user",
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Please retrieve my Audiense insights reports.");
+        return JSON.parse(result);
+    }
+};
+
+const getReportInfoEval: EvalFunction = {
+    name: "get-report-info Evaluation",
+    description: "Evaluates the retrieval of intelligence report information by ID",
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Retrieve the details of the intelligence report with ID 12345, including status, segmentation type, audience size, segments, and access links.");
+        return JSON.parse(result);
+    }
+};
+
+const getAudienceInsightsEval: EvalFunction = {
+    name: "get-audience-insights",
+    description: "Evaluates retrieval of aggregated insights for a specific audience ID",
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Please retrieve aggregated insights for audience ID 'aud123' focusing on demographics and behavioral traits.");
+        return JSON.parse(result);
+    }
+};
+
+const getBaselinesToolEvaluation: EvalFunction = {
+    name: 'Get Baselines Tool Evaluation',
+    description: 'Evaluates the retrieval of available baselines with optional country filtering',
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "What baselines are available for the US?");
+        return JSON.parse(result);
+    }
+};
+
+const getCategoriesEval: EvalFunction = {
+    name: 'get-categories Tool Evaluation',
+    description: 'Evaluates retrieval of the list of available affinity categories for compare-audience-influencers',
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Which categories can be used with the compare-audience-influencers tool?");
+        return JSON.parse(result);
+    }
+};
+
+const config: EvalConfig = {
+    model: openai("gpt-4"),
+    evals: [getReportsEval, getReportInfoEval, getAudienceInsightsEval, getBaselinesToolEvaluation, getCategoriesEval]
+};
+  
+export default config;
+  
+export const evals = [getReportsEval, getReportInfoEval, getAudienceInsightsEval, getBaselinesToolEvaluation, getCategoriesEval];


### PR DESCRIPTION
Adds new e2e test that loads an MCP client, which in turn runs the server and processes the actual tool call. Afterwards, it then grades the response for correctness. 

note: I'm the package author 